### PR TITLE
FIX: media/vimeo

### DIFF
--- a/share/media/vimeo.lua
+++ b/share/media/vimeo.lua
@@ -72,10 +72,11 @@ end
 function Vimeo.config_new(qargs)
   local U = require 'socket.url'
   local t = U.parse(qargs.input_url)
+  t.scheme = 'https'
   t.host = 'player.vimeo.com'
   t.path = table.concat({'/video/', qargs.id})
   local p = quvi.http.fetch(U.build(t)).data
-  return p:match('b=(.-);') or error('no match: b')
+  return p:match('var t=(.-);') or error('no match: b')
 end
 
 function Vimeo.thumb_new(j)

--- a/share/media/vimeo.lua
+++ b/share/media/vimeo.lua
@@ -59,7 +59,7 @@ function Vimeo.can_parse_url(qargs)
   Vimeo.normalize(qargs)
   local U = require 'socket.url'
   local t = U.parse(qargs.input_url)
-  if t and t.scheme and t.scheme:lower():match('^http$')
+  if t and t.scheme and t.scheme:lower():match('^https?$')
        and t.host   and t.host:lower():match('vimeo%.com$')
        and t.path   and t.path:lower():match('^/%d+$')
   then


### PR DESCRIPTION
player JSON data needs to be loaded via https, https-URLs are also acceptable as a source, variable name in JSON data has changed from b to t.
